### PR TITLE
Fix ticker match when crypto name contains a dash

### DIFF
--- a/personalcapital.js
+++ b/personalcapital.js
@@ -8,7 +8,7 @@ function setPrices(holdings, callback) {
             data.forEach(function(c) {
                 holdings.forEach(function(h) {
                     //Trim any special characters
-                    if (h.ticker && h.ticker.toLowerCase().match(/[a-zA-Z]+/g)[0] === c.id) {
+                    if (h.ticker && h.ticker.toLowerCase().match(/[a-z-]+/g)[0] === c.id) {
                         h.price = +c.price_usd;
                         fixed.push(h);
                     }


### PR DESCRIPTION
The coinmarketcap api ticker name for Bitcoin Cash is "bitcoin-cash", and
Ethereum Classic is "ethereum-classic". Also removed the A-Z from the regex
match, since we're calling toLowerCase already.

Tested with a BTC, BCH, ETH, and ETC portfolio.  This plugin is really neat btw, thanks!