### PR TITLE
Add wallet address support to ltc+doge.

### DIFF
--- a/personalcapital.js
+++ b/personalcapital.js
@@ -113,11 +113,13 @@ function getAddressBalances(accountList, callback) {
             if (account.description && account.ticker) {
                 switch (account.ticker.toLowerCase().match(/[a-z-]+/g)[0]) {
                     case 'bitcoin':
-                        return updateBlockcypherBalancePromise(account, 'btc', 1e-8);
+                        return updateBlockcypherBalancePromise(account, 'btc', 1e-8); // 10^8 satoshis/btc
                     case 'litecoin': 
-                        return updateBlockcypherBalancePromise(account, 'ltc', 1e-8);
+                        return updateBlockcypherBalancePromise(account, 'ltc', 1e-8); // 10^8 base units/ltc
+                    case 'dogecoin': 
+                        return updateBlockcypherBalancePromise(account, 'doge', 1e-8); // 10^8 koinus/dogecoin
                     case 'ethereum':
-                        return updateBlockcypherBalancePromise(account, 'eth', 1e-18);
+                        return updateBlockcypherBalancePromise(account, 'eth', 1e-18); // 10^18 wei/eth
                 }
             }
             //No description, no wallet address

--- a/personalcapital.js
+++ b/personalcapital.js
@@ -93,37 +93,31 @@ function getBlockcypherBalance(url) {
     });
 }
 
+function updateBlockcypherBalancePromise(account, symbol, smallestUnit) {
+    return new Promise(function(resolve, reject) {
+        var balanceUrl = 'https://api.blockcypher.com/v1/' + symbol + '/main/addrs/' + account.description + '/balance';
+        getBlockcypherBalance(balanceUrl).then(function(balance) {
+            account.quantity = balance * smallestUnit;
+            console.log('Resolved ' + account.ticker + ' account balance for address ' + account.description + ' as: ' + account.quantity);
+            resolve();
+        }, function(err) {
+            console.log('Error retreiving ' + account.ticker + ' account balance for address ' + account.description + '. Error: ' + err);
+            resolve();
+        });
+    });
+}
+
 function getAddressBalances(accountList, callback) {
     accountList.reduce(function(lastPromise, account) {
         return lastPromise.then(function(result) {
             if (account.description && account.ticker) {
                 switch (account.ticker.toLowerCase().match(/[a-z-]+/g)[0]) {
                     case 'bitcoin':
-                        return new Promise(function(resolve, reject) {
-                            var balanceUrl = 'https://api.blockcypher.com/v1/btc/main/addrs/' + account.description + '/balance';
-                            getBlockcypherBalance(balanceUrl).then(function(balance) {
-                                var satoshi = 1e-8; //smallest unit of btc
-                                account.quantity = balance * satoshi;
-                                console.log('Resolved ' + account.ticker + ' account balance for address ' + account.description + ' as: ' + account.quantity);
-                                resolve();
-                            }, function(err) {
-                                console.log('Error retreiving ' + account.ticker + ' account balance for address ' + account.description + '. Error: ' + err);
-                                resolve();
-                            });
-                        });
+                        return updateBlockcypherBalancePromise(account, 'btc', 1e-8);
+                    case 'litecoin': 
+                        return updateBlockcypherBalancePromise(account, 'ltc', 1e-8);
                     case 'ethereum':
-                        return new Promise(function(resolve, reject) {
-                            var balanceUrl = 'https://api.blockcypher.com/v1/eth/main/addrs/' + account.description + '/balance';
-                            getBlockcypherBalance(balanceUrl).then(function(balance) {
-                                var wei = 1e-18; //smallest unit of eth
-                                account.quantity = balance * wei;
-                                console.log('Resolved ' + account.ticker + ' account balance for address ' + account.description + ' as: ' + account.quantity);
-                                resolve();
-                            }, function(err) {
-                                console.log('Error retreiving ' + account.ticker + ' account balance for address ' + account.description + '. Error: ' + err);
-                                resolve();
-                            });
-                        });
+                        return updateBlockcypherBalancePromise(account, 'eth', 1e-18);
                 }
             }
             //No description, no wallet address


### PR DESCRIPTION
Adds wallet address support (for balance updates) for Litecoin and Dogecoin too.  Also using Blockcypher.  Refactored code very slightly so the Blockcypher promise logic was reusable cleanly.  

LTC+Dogecoin are the remaining two cryptos supported by Blockcypher so it made sense to add them (I only care about LTC but hey, every doge has it's day too).

Testing: using my personal capital account.  Set balances and prices to 0 and verified they updated for BTC+ETH as well as LTC (for my [wallet](https://api.blockcypher.com/v1/ltc/main/addrs/LccTXzvf5BZKaLyuHjgGUcZAbNoN4NrHnz/balance)) and Doge (using their example [wallet](https://api.blockcypher.com/v1/doge/main/addrs/D5EUxodYifpNtfSxTzP4omQMU5JLbMKnWV/balance)).