### PR TITLE
Fix for OMG token

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,18 @@ Example: To successfully add NEO or another currency with the above issue, perso
 
 * Install the extension.
 * In personal capital, add a "Manual Investment Holdings" account. This is under "Add new account... more". If you already have this, you can skip this step.
-* Add a holding in the account edit page. Enter the full name of the crypto currency. Example: "BITCOIN". Enter the number of coins you hold (decimal is fine) and any price.
+* Add a holding in the account edit page. Enter the full name of the crypto currency, or the ticker symbol. Example: "BITCOIN" or "BTC". Enter the number of coins you hold (decimal is fine) and any price.
 * Log out and log back into personal capital. The price will update after about 15-20 seconds and every time you log in in the future.
 
 ~~### Note: Throughout testing I found it to work best when each crypto holding is placed under its own account instead of multiple currencies in the same account. If you have trouble with currencies not updating when refreshing the page, try placing each into its own "Manual Investment Holdings" Account.~~ *Fixed in 0.0.3*
 
 ## Troubleshooting:
-* Make sure the security ticker in personal capital is named the same as the 'id' field (not case sensitive) for the coin from https://api.coinmarketcap.com/v1/ticker.
+* Make sure the security ticker in personal capital is named the same as the 'id' field (not case sensitive) or the 'symbol' field (not case sensitive) for the coin from https://api.coinmarketcap.com/v1/ticker.
   - Example: 'id' is 'bitcoin', security ticker is 'BITCOIN'
+  - Example: 'symbol' is 'BTC', security ticker is 'BTC'
+* When entering a security ticker, personal capital will automatically search for a description matching the ticker. If it finds a description, then the extension may not work even if you delete the auto-populated description or replace it. To prevent personal capital from finding a matching description, place a special character such as "$" at the beginning of the ticker
+  - Example: Typing in the security ticker 'OMG' will automatically fill the description with and prevent the extension from working. Typing '$OMG' for the ticker does not have a matching description and allows the extension to work.
+* If the price is updated for an ERC20 token but not the shares then it may be that the ERC20 token is not listed in the API. To check which tokens appear under your address, go to https://ethplorer.io/address/&lt;youraddress&gt;
 
 ## Notes:
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ basic chome extension to automatically update cryptocurrency holdings (any coin:
 
 ## Changelog
 
+#### 02/07/18:
+
+* Address support for referencing coins by ticker symbol. Set the personal capital security ticker to "$SYMBOL", such as "$BTC"
+
 #### 12/14/17:
 
 * Address support for ERC20 Tokens. Put the wallet address in the "Account Description" field in the format "erc20:address".

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Example: To successfully add NEO or another currency with the above issue, perso
   - Example: 'symbol' is 'BTC', security ticker is 'BTC'
 * When entering a security ticker, personal capital will automatically search for a description matching the ticker. If it finds a description, then the extension may not work even if you delete the auto-populated description or replace it. To prevent personal capital from finding a matching description, place a special character such as "$" at the beginning of the ticker
   - Example: Typing in the security ticker 'OMG' will automatically fill the description with and prevent the extension from working. Typing '$OMG' for the ticker does not have a matching description and allows the extension to work.
-* If the price is updated for an ERC20 token but not the shares then it may be that the ERC20 token is not listed in the API. To check which tokens appear under your address, go to https://ethplorer.io/address/&lt;youraddress&gt;
+* If the price is updated for an ERC20 token but not the shares then it may be that the ERC20 token is not listed in the API. To check which tokens appear under your address, go to `https://ethplorer.io/address/<youraddress>`
 
 ## Notes:
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "pfcrypto",
     "short_name": "personal finance crypto tracker",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "manifest_version": 2,
     "description": "cryptocurrency holdings updater",
     "icons": {

--- a/personalcapital.js
+++ b/personalcapital.js
@@ -27,6 +27,7 @@ function getCoins() {
         getJSON("https://api.coinmarketcap.com/v1/ticker/?limit=0").then(function(coins) {
             var coinmap = coins.reduce(function(map, obj) {
                 map[obj.id] = obj;
+                map[obj.symbol.toLowerCase()] = obj;
                 return map;
             }, {});
             resolve(coinmap);


### PR DESCRIPTION
I want to resolve #10 with this PR.

As outlined in the issue, sometimes the id in the coinmarketcap API differs from the name/symbol in the ethplorer API. This PR will let security tickers refer to coins in coinmarketcap by symbol and not just id. It does this by adding another key to the coins map for the symbol.