### PR TITLE
move external requests to background page for CORS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - run:
           name: "prettier test"
           command: |
-            find $PWD -type f -name *.js | xargs -I {} prettier --check {}
+            find $PWD -type f -name "*.js" | xargs -I {} prettier --check {}
       - run:
           name: "Package Extension"
           command: |

--- a/background.js
+++ b/background.js
@@ -1,0 +1,27 @@
+chrome.runtime.onMessage.addListener(function (request, _sender, sendResponse) {
+  (async () => {
+    switch (request.action) {
+      case 'pfcrypto_request':
+        try {
+          console.log(`fetching data at ${request.url}`);
+          const resp = await fetch(request.url);
+          if (resp.ok) {
+            const data = await resp.json();
+            sendResponse({
+              data,
+              ok: true,
+            });
+          } else {
+            throw new Error('unsuccessful request');
+          }
+        } catch (ex) {
+          sendResponse({
+            ok: false,
+          });
+        }
+      default:
+        break;
+    }
+  })();
+  return true;
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,16 @@
 {
     "name": "pfcrypto",
     "short_name": "personal finance crypto tracker",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "manifest_version": 2,
     "description": "cryptocurrency holdings updater",
     "icons": {
         "48": "icons/icon48.png",
         "128": "icons/icon128.png"
+    },
+    "background": {
+        "scripts": ["background.js"],
+        "persistent": false
     },
     "permissions": [
         "https://home.personalcapital.com/page/login/app*",


### PR DESCRIPTION
Without an Access-Control-Allow-Origin header, external requests to
fetch value/balances need to occur in a background page.

Fixes #17